### PR TITLE
Adding Support for Image Vectors as Icons 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,15 @@ Declare the dependencies in the module-level `build.gradle` file 🍀 [![](https
 ### How to use 🚀
 
 Create list of bottom navigation Item with `SmoothAnimationBottomBarScreens`
+
 ```kotlin
+import javax.swing.Icon
+
 val bottomNavigationItems = listOf(
     SmoothAnimationBottomBarScreens(
         Screens.HomeScreen.route,
         stringResource(id = R.string.home),
-        R.drawable.baseline_home_24
+        Icons.Default.Home
     ), SmoothAnimationBottomBarScreens(
         Screens.TrendingScreen.route,
         stringResource(id = R.string.trending),
@@ -70,7 +73,7 @@ val currentIndex = rememberSaveable {
 }
 
 Scaffold(bottomBar = {
-    SmoothAnimationBottomBar(navController, 
+    SmoothAnimationBottomBar(navController,
         bottomNavigationItems,
         initialIndex = currentIndex,
         bottomBarProperties = BottomBarProperties(),

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ Declare the dependencies in the module-level `build.gradle` file 🍀 [![](https
 Create list of bottom navigation Item with `SmoothAnimationBottomBarScreens`
 
 ```kotlin
-import javax.swing.Icon
-
 val bottomNavigationItems = listOf(
     SmoothAnimationBottomBarScreens(
         Screens.HomeScreen.route,

--- a/SmoothAnimationBottomBar/src/main/java/com/PratikFagadiya/smoothanimationbottombar/model/SmoothAnimationBottomBarScreens.kt
+++ b/SmoothAnimationBottomBar/src/main/java/com/PratikFagadiya/smoothanimationbottombar/model/SmoothAnimationBottomBarScreens.kt
@@ -1,7 +1,13 @@
 package com.PratikFagadiya.smoothanimationbottombar.model
 
+import androidx.compose.ui.graphics.vector.ImageVector
+
 data class SmoothAnimationBottomBarScreens(
     val route: String,
     val name: String,
-    val icon: Int
-)
+    val icon: Int,
+    val imageVector: ImageVector? = null
+) {
+    constructor(route: String, name: String, icon: Int) : this(route, name, icon, null)
+    constructor(route: String, name: String, imageVector: ImageVector) : this(route, name, 0,imageVector)
+}

--- a/SmoothAnimationBottomBar/src/main/java/com/PratikFagadiya/smoothanimationbottombar/ui/SmoothAnimationBottomBar.kt
+++ b/SmoothAnimationBottomBar/src/main/java/com/PratikFagadiya/smoothanimationbottombar/ui/SmoothAnimationBottomBar.kt
@@ -135,11 +135,20 @@ fun SmoothAnimationBottomBar(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.Center) {
 
-                            Icon(
-                                painter = painterResource(id = smoothAnimationBottomBarScreens.icon),
-                                contentDescription = "",
-                                tint = if (initialIndex.value == index) bottomBarProperties.iconTintActiveColor else bottomBarProperties.iconTintColor
-                            )
+                            val tint = if (index == initialIndex.value) bottomBarProperties.iconTintActiveColor else bottomBarProperties.iconTintColor
+                            if (smoothAnimationBottomBarScreens.imageVector != null) {
+                                Icon(
+                                    imageVector = smoothAnimationBottomBarScreens.imageVector,
+                                    contentDescription = smoothAnimationBottomBarScreens.name,
+                                    tint = tint
+                                )
+                            } else {
+                                Icon(
+                                    painter = painterResource(id = smoothAnimationBottomBarScreens.icon),
+                                    contentDescription = smoothAnimationBottomBarScreens.name,
+                                    tint = tint
+                                )
+                            }
 
                             AnimatedVisibility(visible = index == initialIndex.value) {
 


### PR DESCRIPTION
Hello everyone,

I propose adding support for image vectors as icons in the AnimatedSmoothBottomNavigation-JetpackCompose library. Currently, the library only supports drawable resources for icons. By adding support for image vectors, we can provide users with more flexibility and options for customizing their navigation icons.

Proposed Changes:

Modify icon handling to support loading image vectors.
Implement a mechanism for users to specify image vectors as icons.
Update documentation to reflect the changes and provide guidance to users.

Why It's Important:

Allows users to use image vectors for icons, providing more flexibility and customization options.
Aligns the library with modern Android development practices, where image vectors are increasingly used for UI elements.

How You Can Help:

Provide feedback on the proposed changes.
Test the updated functionality and report any bugs or issues.
Contribute code or documentation improvements to support the implementation.